### PR TITLE
Dispatch all error actions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ export default function futureMiddleware({ dispatch }) {
     if (!isFSA(action)) {
       return isFuture(action)
         ? action.fork(
-            error => error.type? dispatch(error): next(action)
+            dispatch
           , dispatch
           )
         : next(action);


### PR DESCRIPTION
**The problem**
If a future is passed to `redux-future`, & the future rejects, an error action will only be dispatched _if_ the future rejects to an object with a valid `type` property. Rejecting with custom actions that will be handled by  custom middleware throw an "Actions must be plain objects" error

**Example**
Full code at https://github.com/mgreystone/demo-redux-future-bug
```javascript
import future from 'redux-future'
import thunk from 'redux-thunk'
import Future from 'fluture'

const reducer = (state = {}) => state

const store = createStore(reducer, applyMiddleware(future, thunk))

const thunkRes = () => dispatch =>
  dispatch({ type: 'RESOLVE' })

const thunkRej = () => dispatch =>
  dispatch({ type: 'REJECT' })

export const resolve = () =>
  Future.after(10, undefined)
    .bimap(thunkRej, thunkRes)

export const reject = () =>
  Future.rejectAfter(10, undefined)
    .bimap(thunkRej, thunkRes)

store.dispatch(resolve()) // dispatches `RESOLVE`

store.dispatch(reject()) // throws Error: Actions must be plain objects,
                         // Use custom middleware for async actions.
```

**This Proposal**
Do not type-check rejected results. Always dispatch errors & allow custom middleware to handle any action it receives.