### PR TITLE
Fix custom action types rejected by futures

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,10 +10,7 @@ export default function futureMiddleware({ dispatch }) {
   return next => action => {
     if (!isFSA(action)) {
       return isFuture(action)
-        ? action.fork(
-            error => error.type? dispatch(error): next(action)
-          , dispatch
-          )
+        ? action.fork(dispatch, dispatch)
         : next(action);
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -12,7 +12,7 @@ import futureMiddleware from '../src';
 describe('redux-future', () => {
   let store, unsubscribe;
 
-  before(() => {
+  beforeEach(() => {
     const initialState =
       { counter: 0
       , filtered: []
@@ -111,7 +111,7 @@ describe('redux-future', () => {
     store.dispatch(filterNumbers());
   });
 
-  it('should work together with IOs', done => {
+  it('should work together with other action types', done => {
     const spy = expect.createSpy()
 
     unsubscribe = store.subscribe(() => {
@@ -132,4 +132,26 @@ describe('redux-future', () => {
     const action = createAction('FUTURE_IO');
     store.dispatch(action(future));
   });
+
+  it('should dispatch other action types correctly on reject', done => {
+    const action = createAction('FUTURE_IO');
+    const spy = expect.createSpy()
+
+    unsubscribe = store.subscribe(() => {
+      expect(store.getState().futureIo).toEqual('errors are bad');
+      expect(spy).toHaveBeenCalled()
+      done();
+    });
+
+    const future = new Future((rej, res) => {
+      const io = IO(() => {
+        spy();
+        return action('errors are bad');
+      });
+
+      setTimeout(() => rej(io), 100);
+    });
+
+    store.dispatch(future);
+  })
 });


### PR DESCRIPTION
![dilbert reject](https://img.memecdn.com/Dilbert-REJECT_o_954.jpg)

Caught this one when we tried to reject with an array of actions and have it handled by [`redux-functor`](https://github.com/articulate/redux-functor).  The arrays were disappearing into the ether and never showing up in the dev tools because it was calling `next(action)` instead of `dispatch(error)`.

So this PR just dispatches both the left and right sides of the future, such that any value rejected or resolved by the future will pass through the entire Redux middleware stack and be handled appropriately.  I also added a test case.

Including @spencerfdavis, because he helped me find this.